### PR TITLE
[BREAKING CHANGES] Rework of datapoint handling

### DIFF
--- a/src/senertec/board.py
+++ b/src/senertec/board.py
@@ -15,7 +15,7 @@ class board(object):
     @property
     def datapointCount(self) -> int:
         """Return number of datapoints."""
-        return self.__datapoints__.count()
+        return len(self.__datapoints__)
     
     @property
     def datapoints(self):

--- a/src/senertec/client.py
+++ b/src/senertec/client.py
@@ -232,7 +232,10 @@ class senertec(basesocketclient):
         metaData = self.__metaDataPoints__
         allPoints = []
         boardList = []
-
+        for b in self.__connectedUnit__["boards"]:
+            device = board()
+            device.__boardName__ = b["name"]
+            boardList.append(device)
         # first collect all available datapoints
         for point in metaData:
             if metaData[point]["friendlyName"] is not None:
@@ -249,11 +252,6 @@ class senertec(basesocketclient):
                 allPoints.append(datap)
                 # loop through all boards of unit
                 for b in self.__connectedUnit__["boards"]:
-                    # add board to the collection if its not already included
-                    if not any(x for x in boardList if x.boardName == b["name"]):
-                        device = board()
-                        device.__boardName__ = b["name"]
-                        boardList.append(device)
                     # loop through datapoints of that board and add available points
                     for at in b["attributes"]:
                         if at == datap.id:

--- a/src/senertec/senertecerror.py
+++ b/src/senertec/senertecerror.py
@@ -1,0 +1,5 @@
+class SenertecError(Exception):
+    """Raised on errors with senertec platform.
+    
+    """
+    pass

--- a/tests/functions_test.py
+++ b/tests/functions_test.py
@@ -1,11 +1,32 @@
+import os
 from time import sleep
 from test_base_test import TestBase
 from src.senertec.canipValue import canipValue
+from src.senertec.obdClass import obdClass
+import json
 
 
 class TestFunctions(TestBase):
     def __init__(self, methodName: str = ...) -> None:
         super().__init__(methodName=methodName)
+        self.counter = 0
+        self.result = []
+        self.totalDataPoints = 0
+        self.timeoutCounter = 0
+
+    def wait_and_print(self):
+        self.timeoutCounter = 0
+        # loop waits 2 second and checks if all points get received
+        while (self.counter < self.totalDataPoints):
+            # break after 60sec timeout
+            if self.timeoutCounter > 30:
+                print("Timeout reached")
+                break
+            sleep(2)
+            self.timeoutCounter += 1
+        # print all values
+        self.printValues()
+        self.assertTrue(self.out.call_count >= self.totalDataPoints)
 
     def test_brennstoffzellenChart(self):
         serial = self.senertec.getUnits()
@@ -19,12 +40,70 @@ class TestFunctions(TestBase):
         errors = self.senertec.getErrors()
         self.assertIsNotNone(errors)
 
-    def test_request(self):
+    def test_request_single(self):
+        self.senertec.messagecallback = self.output
         serial = self.senertec.getUnits()
         self.senertec.connectUnit(serial[0].serial)
-        for points in self.senertec.boards:
-            l = points.getFullDataPointIds()
-            response = self.senertec.request(l)
-            self.assertTrue(response)
-        sleep(10)
-        self.assertTrue(self.out.call_count > 20)
+        self.totalDataPoints = self.senertec.request("IM028")
+        self.assertGreater(self.totalDataPoints, 0)
+        self.wait_and_print()
+
+    def test_request_list(self):
+        self.senertec.messagecallback = self.output
+        serial = self.senertec.getUnits()
+        self.senertec.connectUnit(serial[0].serial)
+        self.totalDataPoints = self.senertec.request(["IM028", "BM001", "FM049", "FM020"])
+        self.assertGreater(self.totalDataPoints, 0)
+        self.wait_and_print()
+
+    def test_request_dict(self):
+        file = open(os.getcwd() + "\\examples\\datapointFilter.json")
+        filter = json.load(file)
+        file.close()
+        self.senertec.messagecallback = self.output
+        serial = self.senertec.getUnits()
+        self.senertec.connectUnit(serial[0].serial)
+        self.totalDataPoints = self.senertec.request(filter)
+        self.assertGreater(self.totalDataPoints, 0)
+        self.wait_and_print()
+
+    def test_request_all(self):
+        self.senertec.messagecallback = self.output
+        serial = self.senertec.getUnits()
+        self.senertec.connectUnit(serial[0].serial)
+        self.totalDataPoints = self.senertec.request(None)
+        self.assertGreater(self.totalDataPoints, 0)
+        self.wait_and_print()
+
+    def test_request_by_type(self):
+        self.senertec.messagecallback = self.output
+        serial = self.senertec.getUnits()
+        self.senertec.connectUnit(serial[0].serial)
+        self.totalDataPoints = self.senertec.request_by_type(obdClass.Signal)
+        self.assertGreater(self.totalDataPoints, 0)
+        self.wait_and_print()
+            
+
+    
+    def printValues(self):
+        for value in self.result:
+            print("\nSource: " + value.sourceDatapoint + "\nBoard: " + value.boardName + "\nName: " + value.friendlyDataName + "\nValue: " +
+              value.dataValue.__str__() + value.dataUnit)
+            
+        print(f"Total count: {self.counter} from {self.totalDataPoints}")
+
+    def output(self, value: canipValue):
+        temp = next(
+            (
+                x
+                for x in self.result
+                if x.sourceDatapoint == value.sourceDatapoint
+            ),
+            None,
+        )
+        # sometimes we get values twice, so we filter it
+        if not temp:
+            self.counter = self.counter + 1
+            self.result.append(value)
+            # call mock method
+            self.out()

--- a/tests/functions_test.py
+++ b/tests/functions_test.py
@@ -44,7 +44,7 @@ class TestFunctions(TestBase):
         self.senertec.messagecallback = self.output
         serial = self.senertec.getUnits()
         self.senertec.connectUnit(serial[0].serial)
-        self.totalDataPoints = self.senertec.request("IM028")
+        self.totalDataPoints = self.senertec.request("AM027")
         self.assertGreater(self.totalDataPoints, 0)
         self.wait_and_print()
 
@@ -80,6 +80,14 @@ class TestFunctions(TestBase):
         serial = self.senertec.getUnits()
         self.senertec.connectUnit(serial[0].serial)
         self.totalDataPoints = self.senertec.request_by_type(obdClass.Signal)
+        self.assertGreater(self.totalDataPoints, 0)
+        self.wait_and_print()
+
+    def test_request_with_board(self):
+        self.senertec.messagecallback = self.output
+        serial = self.senertec.getUnits()
+        self.senertec.connectUnit(serial[0].serial)
+        self.totalDataPoints = self.senertec.request_with_board("AM027", "SCB-04@1")
         self.assertGreater(self.totalDataPoints, 0)
         self.wait_and_print()
             

--- a/tests/properties_test.py
+++ b/tests/properties_test.py
@@ -20,3 +20,8 @@ class TestProperties(TestBase):
         self.assertEqual(self.senertec.__language__, lang.English)
         self.senertec.language = lang.German
         self.assertEqual(self.senertec.__language__, lang.German)
+
+    def test_availableDatapoints(self):
+        serial = self.senertec.getUnits()
+        self.senertec.connectUnit(serial[0].serial)
+        self.assertGreater(self.senertec.availableDatapoints, 0)

--- a/tests/test_base_test.py
+++ b/tests/test_base_test.py
@@ -12,15 +12,11 @@ class TestBase(unittest.TestCase):
         super().__init__(methodName=methodName)
 
     def setUp(self):
-        file = open(os.getcwd() + "\\examples\\datapointFilter.json")
-        supportedItems = json.load(file)
-        file.close()
-        self.senertec = senertec(supportedItems)
+        self.senertec = senertec()
         self.senertec.login(
             os.environ['SENERTECUSER'], os.environ['SENERTECPW'])
         self.senertec.init()
         self.out = Mock()
-        self.senertec.messagecallback = self.out
 
     def tearDown(self):
         self.senertec.logout()


### PR DESCRIPTION
Breaking changes:
- Request functions take the datapoint name directly now (e.g. IM028) instead of the unique id
- Request functions can throw a "SenertecError" exception on errors now
- The normal request function parameters have changed

New:
- New function request_with_board
- New function request_by_type
- New property availableDatapoints